### PR TITLE
Remove "V9" from the application name

### DIFF
--- a/python/platform-api-example.ipynb
+++ b/python/platform-api-example.ipynb
@@ -360,7 +360,7 @@
     "# Now let's try creating an application\n",
     "try:\n",
     "    app_response = create_application(\n",
-    "        name=\"Financial Analysis RAG v9\",\n",
+    "        name=\"Financial Analysis RAG\",\n",
     "        description=\"Application for analyzing the SEC filings of major companies\",\n",
     "        system_guidelines=sample_guideline,\n",
     "        datastore_ids=[datastore_id]\n",


### PR DESCRIPTION
The original application name was "Financial Analysis RAG v9". We should take out the "v9"