### PR TITLE
Amend typo in field

### DIFF
--- a/python/platform-api-example.ipynb
+++ b/python/platform-api-example.ipynb
@@ -366,7 +366,7 @@
     "        datastore_ids=[datastore_id]\n",
     "    )\n",
     "    # Store application ID for later use\n",
-    "    application_id = app_response['id']\n",
+    "    application_id = app_response['application_id']\n",
     "    print(f\"Application ID created: {application_id}\")\n",
     "except requests.exceptions.RequestException as e:\n",
     "    print(f\"Error creating application: {e}\")"


### PR DESCRIPTION
The field should be "application_id" not "id". See screenshots

Using field "id":
<img width="795" alt="image" src="https://github.com/user-attachments/assets/c051febb-cb3b-4cde-8fa5-e75546243d52">

Using field "application_id":
<img width="807" alt="image" src="https://github.com/user-attachments/assets/f616c9af-7f8d-412e-9472-7afe225f8bd6">
